### PR TITLE
Add submodule helpers and Godot installer

### DIFF
--- a/add_submodules.sh
+++ b/add_submodules.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./add_submodules.sh [repo-url submodule-path [branch]]
+# Adds the specified submodule if it doesn't exist and updates all submodules.
+
+if [[ $# -ge 2 ]]; then
+    repo_url="$1"
+    submodule_path="$2"
+    branch="${3:-main}"
+
+    if ! git config --get submodule."$submodule_path".url > /dev/null; then
+        git submodule add -b "$branch" "$repo_url" "$submodule_path"
+    fi
+fi
+
+# Initialize and update submodules
+
+git submodule update --init --recursive
+
+git submodule update --remote --merge

--- a/install_godot.sh
+++ b/install_godot.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads Godot binaries and places them in the tools/ directory.
+# Usage: ./install_godot.sh [version]
+
+version="${1:-4.2.1}"
+platform="linux.x86_64"
+
+base_url="https://downloads.tuxfamily.org/godotengine/${version}"
+file="Godot_v${version}-stable_${platform}.zip"
+url="${base_url}/${file}"
+
+target_dir="$(dirname "$0")/tools"
+mkdir -p "$target_dir"
+
+tmp_zip=$(mktemp)
+
+echo "Downloading Godot ${version} from ${url}..."
+curl -L "$url" -o "$tmp_zip"
+
+echo "Extracting to $target_dir..."
+unzip -o "$tmp_zip" -d "$target_dir"
+
+rm "$tmp_zip"
+
+echo "Godot installed in $target_dir"


### PR DESCRIPTION
## Summary
- add an `add_submodules.sh` helper to manage git submodules
- add an `install_godot.sh` script for fetching Godot binaries

## Testing
- `bash -n add_submodules.sh`
- `bash -n install_godot.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a7b248d58832f8ccccd03ff507689