### PR TITLE
Add submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,15 @@
+[submodule "addons/Humanizer"]
+    path = addons/Humanizer
+    url = https://github.com/Bauxitedev/Humanizer.git
+[submodule "addons/godot_openxr"]
+    path = addons/godot_openxr
+    url = https://github.com/GodotVR/godot_openxr.git
+[submodule "tools/MB-Lab"]
+    path = tools/MB-Lab
+    url = https://github.com/animate1978/MB-Lab.git
+[submodule "tools/rigodotify"]
+    path = tools/rigodotify
+    url = https://github.com/arkokoley/rigodotify.git
+[submodule "tools/godot-engine"]
+    path = tools/godot-engine
+    url = https://github.com/godotengine/godot.git


### PR DESCRIPTION
## Summary
- configure submodules for Humanizer, godot_openxr, MB-Lab, rigodotify, and optional Godot engine
- initialize submodules

## Testing
- `pytest -q`
- `git submodule init`

------
https://chatgpt.com/codex/tasks/task_e_685a7b2388f8832fba2658e938ce0124